### PR TITLE
Aujout du tag MS aux device. Suppression device de MesObservationPainSeverity et MesObservationWaistCircumference

### DIFF
--- a/input/fsh/MesFrObservationBmi.fsh
+++ b/input/fsh/MesFrObservationBmi.fsh
@@ -9,6 +9,7 @@ Id: mesures-fr-observation-bmi
 * dataAbsentReason.coding.code 1..
 
 * device only Reference($PhdDevice)
+* device MS
 * device ^short = "Dispositif utilisé pour l'observation"
 * device ^definition = "Dispositif utilisé pour l'observation\r\nSi la mesure a été faite par un objet connecté (Profil PhdDevice) \r\n=>cette référence est obligatoire"
 

--- a/input/fsh/MesFrObservationBodyHeight.fsh
+++ b/input/fsh/MesFrObservationBodyHeight.fsh
@@ -1,4 +1,3 @@
-
 Profile: MesFrObservationBodyHeight
 Parent: $FrObservationBodyHeight
 Id: mesures-fr-observation-bodyheight

--- a/input/fsh/MesFrObservationBodyHeight.fsh
+++ b/input/fsh/MesFrObservationBodyHeight.fsh
@@ -23,8 +23,8 @@ Id: mesures-fr-observation-bodyheight
 * method ^binding.description = $JDV-J158-MethodStepsByDay-MES
 
 * device only Reference($PhdDevice)
-* device ^short = "Dispositif utilisé pour l'observation"
-* device ^definition = "Dispositif utilisé pour l'observation\r\nSi la mesure a été faite par un objet connecté (Profil PhdDevice) =>cette référence est obligatoire"
+* device MS
+* device ^short = "Dispositif utilisé pour l'observation\r\nSi la mesure a été faite par un objet connecté (Profil PhdDevice), cette référence est obligatoire"
 
 
 * interpretation from http://hl7.org/fhir/ValueSet/observation-interpretation (extensible)

--- a/input/fsh/MesFrObservationBodyTemperature.fsh
+++ b/input/fsh/MesFrObservationBodyTemperature.fsh
@@ -32,8 +32,8 @@ Id: mesures-fr-observation-body-temperature
 * method.coding.code 1..
 
 * device only Reference($PhdDevice)
-* device ^short = "Dispositif utilisé pour l'observation"
-* device ^definition = "Dispositif utilisé pour l'observation\r\nSi la mesure a été faite par un objet connecté (Profil PhdDevice)\r\n=>cette référence est obligatoire\r\nhttp://hl7.org/fhir/uv/phd/StructureDefinition/PhdDevice"
+* device MS
+* device ^short = "Dispositif utilisé pour l'observation\r\nSi la mesure a été faite par un objet connecté (Profil PhdDevice)\r\n, cette référence est obligatoire"
 
 
 * interpretation from http://hl7.org/fhir/ValueSet/observation-interpretation (extensible)

--- a/input/fsh/MesFrObservationBodyTemperature.fsh
+++ b/input/fsh/MesFrObservationBodyTemperature.fsh
@@ -1,4 +1,3 @@
-
 Profile: MesFrObservationBodyTemperature
 Parent: $FrObservationBodyTemperature
 Id: mesures-fr-observation-body-temperature

--- a/input/fsh/MesFrObservationBodyWeight.fsh
+++ b/input/fsh/MesFrObservationBodyWeight.fsh
@@ -1,4 +1,3 @@
-
 Profile: MesFrObservationBodyWeight
 Parent: $FrObservationBodyWeight
 Id: mesures-fr-observation-body-weight

--- a/input/fsh/MesFrObservationBodyWeight.fsh
+++ b/input/fsh/MesFrObservationBodyWeight.fsh
@@ -23,8 +23,8 @@ Description: "Poids du patient"
 * method ^binding.description = $JDV-J145-MethodBodyWeight-MES
 
 * device only Reference($PhdDevice)
-* device ^short = "Dispositif utilisé pour l'observation"
-* device ^definition = "Dispositif utilisé pour l'observation\nSi la mesure a été faite par un objet connecté (Profil PhdDevice)\n=>cette référence est obligatoire"
+* device MS
+* device ^short = "Dispositif utilisé pour l'observation\nSi la mesure a été faite par un objet connecté (Profil PhdDevice)\n, cette référence est obligatoire"
 
 
 * interpretation from http://hl7.org/fhir/ValueSet/observation-interpretation (extensible)

--- a/input/fsh/MesFrObservationBp.fsh
+++ b/input/fsh/MesFrObservationBp.fsh
@@ -1,4 +1,3 @@
-
 Profile: MesFrObservationBp
 Parent: $FrObservationBp
 Id: mesures-fr-observation-bp

--- a/input/fsh/MesFrObservationBp.fsh
+++ b/input/fsh/MesFrObservationBp.fsh
@@ -28,8 +28,8 @@ Description: "Pression artérielle - profil créé pour l'alimentation de l'Espa
 * method.coding.code 1..
 
 * device only Reference($PhdDevice)
-* device ^definition = "Dispositif utilisé pour l'observation\r\nSi la mesure a été faite par un objet connecté (Profil PhdDevice) =>cette référence est obligatoire"
-* device.reference 1..
+* device MS
+* device ^short = "Dispositif utilisé pour l'observation\r\nSi la mesure a été faite par un objet connecté (Profil PhdDevice), cette référence est obligatoire"
 
 * referenceRange.appliesTo from $JDV-J148-ReferenceRangeAppliesTo-CISIS (required)
 * referenceRange.appliesTo ^binding.description = $JDV-J148-ReferenceRangeAppliesTo-CISIS

--- a/input/fsh/MesFrObservationHeartrate.fsh
+++ b/input/fsh/MesFrObservationHeartrate.fsh
@@ -27,8 +27,8 @@ Id: mesures-fr-observation-heartrate
 * method ^binding.description = $JDV-J147-MethodHeartrate-MES
 
 * device only Reference($PhdDevice)
-* device ^short = "Dispositif utilisé pour l'observation"
-* device ^definition = "Dispositif utilisé pour l'observation\r\nSi la mesure a été faite par un objet connecté (Profil PhdDevice)\r\n=>cette référence est obligatoire"
+* device MS
+* device ^short = "Dispositif utilisé pour l'observation\r\nSi la mesure a été faite par un objet connecté (Profil PhdDevice), cette référence est obligatoire"
 
 * referenceRange.appliesTo from $JDV-J148-ReferenceRangeAppliesTo-CISIS (required)
 * referenceRange.appliesTo ^binding.description = $JDV-J148-ReferenceRangeAppliesTo-CISIS

--- a/input/fsh/MesObservationGlucose.fsh
+++ b/input/fsh/MesObservationGlucose.fsh
@@ -53,7 +53,8 @@ L'extension MesMomentOfMeasurement (contexte de la mesure) est utilisée dans le
 * method.coding.code 1..1
 
 * device only Reference($PhdDevice)
-* device ^definition = "Dispositif utilisé pour l'observation\r\nSi la mesure a été faite par un objet connecté (Profil PhdDevice) =>cette référence est obligatoire"
+* device MS
+* device ^short = "Dispositif utilisé pour l'observation\r\nSi la mesure a été faite par un objet connecté (Profil PhdDevice), cette référence est obligatoire"
 
 * referenceRange.appliesTo from $JDV-J148-ReferenceRangeAppliesTo-CISIS (required)
 * referenceRange.appliesTo ^binding.description = "JDV_J148-ReferenceRangeAppliesTo-CISIS"

--- a/input/fsh/MesObservationPainSeverity.fsh
+++ b/input/fsh/MesObservationPainSeverity.fsh
@@ -34,7 +34,3 @@ Description: "Niveau de douleur - profil créé pour l'alimentation de l'Espace 
 * method ^binding.description = $JDV-J159-MethodPainSeverity-MES
 * method.coding.system 1..
 * method.coding.code 1..
-
-* device only Reference($PhdDevice)
-* device ^short = "Dispositif utilisé pour l'observation"
-* device ^definition = "Dispositif utilisé pour l'observation\r\nSi la mesure a été faite par un objet connecté (Profil PhdDevice) =>cette référence est obligatoire\r\nhttp://hl7.org/fhir/uv/phd/StructureDefinition/PhdDevice"

--- a/input/fsh/MesObservationStepsByDay.fsh
+++ b/input/fsh/MesObservationStepsByDay.fsh
@@ -33,5 +33,5 @@ Id: mesures-observation-steps-by-day
 * method.coding.code 1..
 
 * device only Reference($PhdDevice)
-* device ^short = "Dispositif utilisé pour l'observation"
-* device ^definition = "Dispositif utilisé pour l'observation\r\nSi la mesure a été faite par un objet connecté (Profil PhdDevice)\r\n=>cette référence est obligatoire"
+* device MS
+* device ^short = "Dispositif utilisé pour l'observation\r\nSi la mesure a été faite par un objet connecté (Profil PhdDevice), cette référence est obligatoire"

--- a/input/fsh/MesObservationWaistCircumference.fsh
+++ b/input/fsh/MesObservationWaistCircumference.fsh
@@ -26,5 +26,5 @@ Id: mesures-observation-waist-circumference
 
 
 * device only Reference($PhdDevice)
-* device ^short = "Dispositif utilisé pour l'observation"
-* device ^definition = "Dispositif utilisé pour l'observation\r\nSi la mesure a été faite par un objet connecté (Profil PhdDevice)\r\n=>cette référence est obligatoire"
+* device MS
+* device ^short = "Dispositif utilisé pour l'observation\r\nSi la mesure a été faite par un objet connecté (Profil PhdDevice), cette référence est obligatoire"


### PR DESCRIPTION
MS device :
- Added to : MesFrObservationBmi, MesFrObservationBodyHeight, MesFrObservationBodyTemperature, MesFrObservationBodyWeight, MesFrObservationBp, MesFrObservationHeartrate, MesObservationGlucose, MesObservationStepsByDay, 
- Removed device information for MesObservationPainSeverity, MesObservationWaistCircumference (à confirmer @nicolasArnoux, Alex Roncati)

preview : https://ansforge.github.io/IG-fhir-mesures-de-sante/ig/nr-add-MS-device-method


## Impact API MES

Aucun