### PR TITLE
Ajout tag MS à method et passage du binding required à extensible 

### DIFF
--- a/input/fsh/MesFrObservationBodyHeight.fsh
+++ b/input/fsh/MesFrObservationBodyHeight.fsh
@@ -18,9 +18,8 @@ Id: mesures-fr-observation-bodyheight
 * dataAbsentReason.coding.system 1..
 * dataAbsentReason.coding.code 1..
 
-
-* method from $JDV-J146-MethodBodyHeight-MES (required)
-* method ^binding.description = $JDV-J158-MethodStepsByDay-MES
+* method MS
+* method from $JDV-J146-MethodBodyHeight-MES (extensible)
 
 * device only Reference($PhdDevice)
 * device ^short = "Dispositif utilisé pour l'observation"

--- a/input/fsh/MesFrObservationBodyTemperature.fsh
+++ b/input/fsh/MesFrObservationBodyTemperature.fsh
@@ -26,10 +26,8 @@ Id: mesures-fr-observation-body-temperature
 * bodySite.coding.system 1..
 * bodySite.coding.code 1..
 
-* method from $JDV-J152-MethodBodyTemperature-MES (required)
-* method ^binding.description = $JDV-J152-MethodBodyTemperature-MES
-* method.coding.system 1..
-* method.coding.code 1..
+* method MS
+* method from $JDV-J152-MethodBodyTemperature-MES (extensible)
 
 * device only Reference($PhdDevice)
 * device ^short = "Dispositif utilisé pour l'observation"

--- a/input/fsh/MesFrObservationBodyWeight.fsh
+++ b/input/fsh/MesFrObservationBodyWeight.fsh
@@ -19,8 +19,9 @@ Description: "Poids du patient"
 
 * dataAbsentReason.coding.system 1..
 * dataAbsentReason.coding.code 1..
-* method from $JDV-J145-MethodBodyWeight-MES (required)
-* method ^binding.description = $JDV-J145-MethodBodyWeight-MES
+
+* method MS
+* method from $JDV-J145-MethodBodyWeight-MES (extensible)
 
 * device only Reference($PhdDevice)
 * device ^short = "Dispositif utilisé pour l'observation"

--- a/input/fsh/MesFrObservationBp.fsh
+++ b/input/fsh/MesFrObservationBp.fsh
@@ -22,10 +22,8 @@ Description: "Pression artérielle - profil créé pour l'alimentation de l'Espa
 * bodySite.coding.system 1..
 * bodySite.coding.code 1..
 
-* method from $JDV-J150-MethodBP-MES (required)
-* method ^binding.description = $JDV-J150-MethodBP-MES
-* method.coding.system 1..
-* method.coding.code 1..
+* method MS
+* method from $JDV-J150-MethodBP-MES (extensible)
 
 * device only Reference($PhdDevice)
 * device ^definition = "Dispositif utilisé pour l'observation\r\nSi la mesure a été faite par un objet connecté (Profil PhdDevice) =>cette référence est obligatoire"

--- a/input/fsh/MesFrObservationHeartrate.fsh
+++ b/input/fsh/MesFrObservationHeartrate.fsh
@@ -21,10 +21,9 @@ Id: mesures-fr-observation-heartrate
 * dataAbsentReason.coding.system 1..
 * dataAbsentReason.coding.code 1..
 
-* method from $JDV-J147-MethodHeartrate-MES (required)
+* method MS
+* method from $JDV-J147-MethodHeartrate-MES (extensible)
 * method ^short = "Méthode de la mesure"
-* method ^definition = "Méthode de la mesure"
-* method ^binding.description = $JDV-J147-MethodHeartrate-MES
 
 * device only Reference($PhdDevice)
 * device ^short = "Dispositif utilisé pour l'observation"

--- a/input/fsh/MesObservationGlucose.fsh
+++ b/input/fsh/MesObservationGlucose.fsh
@@ -47,10 +47,8 @@ L'extension MesMomentOfMeasurement (contexte de la mesure) est utilisée dans le
 * dataAbsentReason.coding.system 1..
 * dataAbsentReason.coding.code 1..
 
-* method from method-glucose-vs (required)
-* method ^short = "JDV pour la glycémie"
-* method.coding.system 1..1
-* method.coding.code 1..1
+* method MS
+* method from method-glucose-vs (extensible)
 
 * device only Reference($PhdDevice)
 * device ^definition = "Dispositif utilisé pour l'observation\r\nSi la mesure a été faite par un objet connecté (Profil PhdDevice) =>cette référence est obligatoire"

--- a/input/fsh/MesObservationPainSeverity.fsh
+++ b/input/fsh/MesObservationPainSeverity.fsh
@@ -28,13 +28,6 @@ Description: "Niveau de douleur - profil créé pour l'alimentation de l'Espace 
 * dataAbsentReason.coding.code 1..
 
 * bodySite ^short = "Lieu de la douleur - Texte libre"
-* bodySite ^definition = "Lieu de la douleur - Texte libre"
 
-* method from $JDV-J159-MethodPainSeverity-MES (required)
-* method ^binding.description = $JDV-J159-MethodPainSeverity-MES
-* method.coding.system 1..
-* method.coding.code 1..
-
-* device only Reference($PhdDevice)
-* device ^short = "Dispositif utilisé pour l'observation"
-* device ^definition = "Dispositif utilisé pour l'observation\r\nSi la mesure a été faite par un objet connecté (Profil PhdDevice) =>cette référence est obligatoire\r\nhttp://hl7.org/fhir/uv/phd/StructureDefinition/PhdDevice"
+* method MS
+* method from $JDV-J159-MethodPainSeverity-MES (extensible)

--- a/input/fsh/MesObservationStepsByDay.fsh
+++ b/input/fsh/MesObservationStepsByDay.fsh
@@ -27,10 +27,8 @@ Id: mesures-observation-steps-by-day
 * dataAbsentReason.coding.system 1..
 * dataAbsentReason.coding.code 1..
 
-* method from $JDV-J158-MethodStepsByDay-MES (required)
-* method ^binding.description = $JDV-J158-MethodStepsByDay-MES
-* method.coding.system 1..
-* method.coding.code 1..
+* method MS
+* method from $JDV-J158-MethodStepsByDay-MES (extensible)
 
 * device only Reference($PhdDevice)
 * device ^short = "Dispositif utilisé pour l'observation"


### PR DESCRIPTION
Ajout MS method pour les profils : 
- input/fsh/MesFrObservationBodyHeight.fsh
- input/fsh/MesFrObservationBodyTemperature.fsh
- input/fsh/MesFrObservationBodyWeight.fsh
- input/fsh/MesFrObservationBp.fsh
- input/fsh/MesFrObservationHeartrate.fsh
- input/fsh/MesObservationGlucose.fsh
- input/fsh/MesObservationPainSeverity.fsh
- input/fsh/MesObservationStepsByDay.fsh

Pour method, passage de required à extensible

Mon Espace Santé : le passage de required à extensible fait que les erreurs ne seront plus remontées si le code n'existe pas. Si besoin de valider --> il suffit de repasser le binding à required dans les profils Mon Espace Santé.

preview : https://ansforge.github.io/IG-fhir-mesures-de-sante/ig/nr-add-ms-method/


## Impact MES
Aucun impact pour le tag MS
Faible impact : le binding de Observation.method est passé de required à extensible, donc les validateurs ne feront plus d'erreurs si un autre code est renseigné par l'éditeur (possibilité de le re-contraindre côté MES)